### PR TITLE
[Link] Added basic battery info

### DIFF
--- a/lil-link/src/common/identifiers.rs
+++ b/lil-link/src/common/identifiers.rs
@@ -9,6 +9,12 @@ pub static IDENT_STATUS_TEXT: &str = "text";
 pub static IDENT_STATUS_SENSORS: &str = "sensors";
 pub static IDENT_STATUS_EKF: &str = "ekf";
 pub static IDENT_STATUS_HEALTH: &str = "health";
+pub static IDENT_STATUS_BATTERY: &str = "battery";
+pub static IDENT_STATUS_DROP_RATE_COMM: &str = "drop_rate_comm";
+pub static IDENT_STATUS_VOLTAGE: &str = "voltage";
+pub static IDENT_STATUS_CURRENT: &str = "current";
+pub static IDENT_STATUS_COMM_ERRORS: &str = "comm_errors";
+pub static IDENT_STATUS_ERRORS_COUNT: &str = "errors_count";
 pub static IDENT_COMMAND_ACK: &str = "command_ack";
 
 pub static IDENT_POSE_NED: &str = "ned";

--- a/lil-link/src/mavlink/processors/proc_sys_status.rs
+++ b/lil-link/src/mavlink/processors/proc_sys_status.rs
@@ -1,7 +1,7 @@
 use victory_data_store::{database::DataView, topics::TopicKey};
 
 use crate::{
-    common::identifiers::{IDENT_BASE_STATUS, IDENT_STATUS_SENSORS},
+    common::identifiers::*,
     mavlink::{core::MavlinkMessageType, helpers::MavLinkHelper},
 };
 
@@ -29,6 +29,32 @@ impl MavlinkMessageProcessor for SysStatusProcessor {
         let topic_key =
             TopicKey::from_str(&format!("{}/{}", IDENT_BASE_STATUS, IDENT_STATUS_SENSORS));
         data_view.add_latest(&topic_key, sensor_status)?;
+
+        let battery_status = sys_status_msg.battery_remaining;
+        let drop_rate_comm = sys_status_msg.drop_rate_comm;
+        let voltage = sys_status_msg.voltage_battery;
+        let current = sys_status_msg.current_battery;
+        let comm_errors = sys_status_msg.errors_comm;
+        let errors_count = sys_status_msg.errors_count1 + sys_status_msg.errors_count2 + sys_status_msg.errors_count3; 
+
+        let battery_topic_key = TopicKey::from_str(&format!("{}/{}", IDENT_BASE_STATUS, IDENT_STATUS_BATTERY));
+        data_view.add_latest(&battery_topic_key, battery_status)?;
+
+        let drop_rate_comm_topic_key = TopicKey::from_str(&format!("{}/{}", IDENT_BASE_STATUS, IDENT_STATUS_DROP_RATE_COMM));
+        data_view.add_latest(&drop_rate_comm_topic_key, drop_rate_comm)?;
+
+        let voltage_topic_key = TopicKey::from_str(&format!("{}/{}", IDENT_BASE_STATUS, IDENT_STATUS_VOLTAGE));
+        data_view.add_latest(&voltage_topic_key, voltage)?;
+
+        let current_topic_key = TopicKey::from_str(&format!("{}/{}", IDENT_BASE_STATUS, IDENT_STATUS_CURRENT));
+        data_view.add_latest(&current_topic_key, current)?;
+
+        let comm_errors_topic_key = TopicKey::from_str(&format!("{}/{}", IDENT_BASE_STATUS, IDENT_STATUS_COMM_ERRORS));
+        data_view.add_latest(&comm_errors_topic_key, comm_errors)?;
+
+        let errors_count_topic_key = TopicKey::from_str(&format!("{}/{}", IDENT_BASE_STATUS, IDENT_STATUS_ERRORS_COUNT));
+        data_view.add_latest(&errors_count_topic_key, errors_count)?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
        // Publish to status topics:
        // - Battery remaining percentage (status/battery)
        // - Communication drop rate (status/drop_rate_comm) 
        // - Battery voltage (status/voltage)
        // - Battery current (status/current)
        // - Communication errors (status/comm_errors)
        // - Total error count across all types (status/errors_count)